### PR TITLE
Finilize functionality of color space change API

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/misc/ChangeColorSpaceController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/misc/ChangeColorSpaceController.java
@@ -1,5 +1,6 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import java.awt.color.ICC_Profile;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
@@ -43,9 +44,11 @@ public class ChangeColorSpaceController {
     public ResponseEntity<byte[]> updateColorSpace(
             @ModelAttribute ChangeColorSpaceRequest changeColorSpaceRequest) throws IOException {
         PDDocument document = pdfDocumentFactory.load(changeColorSpaceRequest);
+        ICC_Profile icc =
+                changeColorSpaceService.loadICCProfile(changeColorSpaceRequest.getIccProfileName());
         PDDocument modifiedDocument =
                 changeColorSpaceService.changeColorSpace(
-                        document, null // Change this null into a real icc-profile
+                        document, icc // Change this null into a real icc-profile
                         );
 
         // Create a ByteArrayOutputStream to hold the modified PDF data

--- a/src/main/java/stirling/software/SPDF/model/api/misc/ChangeColorSpaceRequest.java
+++ b/src/main/java/stirling/software/SPDF/model/api/misc/ChangeColorSpaceRequest.java
@@ -1,30 +1,22 @@
 package stirling.software.SPDF.model.api.misc;
 
-import java.awt.color.ICC_ColorSpace;
-import java.awt.color.ICC_Profile;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
 import stirling.software.SPDF.model.api.PDFFile;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class ChangeColorSpaceRequest extends PDFFile {
-    private ICC_Profile iccProfile;
-    private ICC_ColorSpace cmykColorSpace;
 
-    public ChangeColorSpaceRequest() throws IOException {
-        String iccFilePath = "resources/static/Coated_Fogra39L_VIGC_300.icc";
-
-        try (InputStream iccProfileStream = new FileInputStream(iccFilePath)) {
-            this.iccProfile = ICC_Profile.getInstance(iccProfileStream);
-        } catch (FileNotFoundException e) {
-            System.err.println("ICC-profilen kunde inte hittas: " + iccFilePath);
-        }
-        this.cmykColorSpace = new ICC_ColorSpace(iccProfile);
-    }
+    @Schema(
+            description =
+                    "The name (or identifier) of the ICC profile to use. "
+                            + "For example: 'Coated_Fogra39L_VIGC_300.icc'",
+            example = "Coated_Fogra39L_VIGC_300.icc",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+            defaultValue = "Coated_Fogra39L_VIGC_300.icc")
+    private String iccProfileName;
 }

--- a/src/main/java/stirling/software/SPDF/utils/ChangeColorSpace.java
+++ b/src/main/java/stirling/software/SPDF/utils/ChangeColorSpace.java
@@ -5,17 +5,15 @@ import java.awt.color.ICC_Profile;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorConvertOp;
 import java.io.IOException;
-import java.io.InputStream;
 
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 
 public class ChangeColorSpace {
 
-    public static BufferedImage transformToICC(PDImageXObject src, InputStream icc_profile)
+    public static BufferedImage transformToICC(PDImageXObject src, ICC_Profile icc_profile)
             throws IOException {
         BufferedImage src_img = src.getImage();
-        ICC_Profile ip = ICC_Profile.getInstance(icc_profile);
-        ICC_ColorSpace ics = new ICC_ColorSpace(ip);
+        ICC_ColorSpace ics = new ICC_ColorSpace(icc_profile);
         ColorConvertOp cco = new ColorConvertOp(ics, null);
         BufferedImage result = cco.filter(src_img, null);
         return result;

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -753,7 +753,8 @@ changeColorspace.title=Change Colour space
 changeColorspace.header=Change Colour space
 changeColorspace.download=Download
 changeColorspace.selectText.1=Target Colour Space
-changeColorspace.selectText.2=(Default) Standard CMYK
+changeColorspace.selectText.2=(Default) Coated Fogra39L
+adjustContrast.download=Download
 
 #crop
 crop.title=Crop

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -753,7 +753,7 @@ changeColorspace.title=Change Color space
 changeColorspace.header=Change Color space
 changeColorspace.download=Download
 changeColorspace.selectText.1=Target Color Space
-changeColorspace.selectText.2=(Default) Standard CMYK
+changeColorspace.selectText.2=(Default) Coated Fogra39L
 
 #crop
 crop.title=Crop

--- a/src/main/resources/templates/misc/change-color-space.html
+++ b/src/main/resources/templates/misc/change-color-space.html
@@ -20,39 +20,28 @@
         <br><br>
         <div class="container">
           <div class="row justify-content-center">
-            <div class="col-md-12 bg-card">
-              <form th:action="@{''}">
-              <div class="row justify-content-center">
-
-                <div class="col-md-7">
+              <div class="col-md-6 bg-card">
                   <div class="tool-header">
-                    <span class="material-symbols-rounded tool-header-icon advance">palette</span>
-                    <span class="tool-header-text" th:text="#{changeColorspace.header}"></span>
+                      <span class="material-symbols-rounded tool-header-icon advance">palette</span>
+                      <span class="tool-header-text" th:text="#{changeColorspace.header}"></span>
                   </div>
-                  <div class="col-md-8">
-                    <div th:replace="~{fragments/common :: fileSelector(name='fileInput', multipleInputsForSingleRequest=false, accept='application/pdf', remoteCall='false')}"></div>
-                    <div class="card mb-3">
-                        <div class="card-body">
-                            <h4 th:text="#{changeColorspace.selectText.1}"></h4>
-                            <select name="colorChangeOption" id="colorChange" class="form-control">
-                                <option value="Standard CMYK" th:text="#{changeColorspace.selectText.2}" selected></option>
-                            </select>
-                        </div>
-                    </div>
-                  </div>
-                  <br>
-                  <canvas id="contrast-pdf-canvas"></canvas>
-                  <div class="mb-3 text-left">
-                  <button id="download-button" class="btn btn-primary" th:text="#{changeColorspace.download}"></button>
-                  </div>
-                </div>
+                  <form action="#" th:action="@{'/api/v1/misc/change-color-space-pdf'}" method="post" enctype="multipart/form-data">
+                      <div
+                              th:replace="~{fragments/common :: fileSelector(name='fileInput', multipleInputsForSingleRequest=false, accept='application/pdf')}">
+                      </div>
+                      <div class="card mb-3">
+                          <div class="card-body">
+                              <h4 th:text="#{changeColorspace.selectText.1}"></h4>
+                              <select name="iccProfileName" id="iccProfileName" class="form-control">
+                                  <option value="Coated_Fogra39L_VIGC_300.icc" th:text="#{changeColorspace.selectText.2}" selected></option>
+                              </select>
+                          </div>
+                      </div>
+                      <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{changeColorspace.download}"></button>
+                  </form>
               </div>
-              </form>
-              <script type="module" th:src="@{'/pdfjs-legacy/pdf.mjs'}"></script>
-              <script type="module" th:src="@{'/js/pages/change-color-space.js'}"></script>
-            </div>
           </div>
-        </div>
+      </div>
       </div>
       <th:block th:insert="~{fragments/footer.html :: footer}"></th:block>
     </div>


### PR DESCRIPTION
These changes finalize the functionality of the color space change API. Requests can now be done from the related tool, and is automatically downloaded, and seems to work fine.

Important note is that there currently is only one available ICC profile, and that the program does not expect resources from `src/main/resources` but instead the root directory, which is not ideal. This will be needed to be changed before merging to main.

There are also no tests that check the functionality of the code, for example if the color conversion is done properly.